### PR TITLE
Fix typo in voltage warning for Calliope mini

### DIFF
--- a/src/content/tech/[...02]hardware/[...03]stromversorgung/index.page
+++ b/src/content/tech/[...02]hardware/[...03]stromversorgung/index.page
@@ -38,7 +38,7 @@ Der Calliope mini kann über die folgenden Möglichkeiten mit Spannung versorgt 
         <li> über den JST Batterie Konnector (max 5V):
 <ul> <li> mit 2x AAA Batterien (Standard)
 <li> oder auch einer LiPo Zelle.
-<br> <b> Vorsicht: Der Calliope mini 1 und 2 verträgt hier nur maximal 3.3V! Eine höhre Spannung würde zu einem Defekt führen. </b> </li> </ul>
+<br> <b> Vorsicht: Der Calliope mini 1 und 2 verträgt hier nur maximal 3.3V! Eine höhere Spannung würde zu einem Defekt führen. </b> </li> </ul>
 <li>über den USB-C Anschluss (5V)</li>
 <li>über den VM Pin (maximal 9V)</li>
 <li>über den Pluspin (VCC) maximal 3,3V


### PR DESCRIPTION
Corrected a typo in the warning about voltage limits for the Calliope mini.